### PR TITLE
Update css source map when adding prefixes

### DIFF
--- a/lib/autoprefixer-rails/sprockets.rb
+++ b/lib/autoprefixer-rails/sprockets.rb
@@ -11,9 +11,34 @@ module AutoprefixerRails
 
     # Sprockets 3 and 4 API
     def self.call(input)
-      filename = input[:filename]
-      source   = input[:data]
-      run(filename, source)
+      filename     = input[:filename]
+      source       = input[:data]
+      previous_map = input[:metadata] && input[:metadata][:map]
+
+      output = filename.chomp(File.extname(filename)) + ".css"
+      map_param = previous_map ? {
+        inline: false, # do not generate inline source map
+        prev: false, # omit previous source map if embedded in source css
+        annotation: false, # do not append source map comment to css
+        sourcesContent: false,
+      } : nil
+      result = @processor.process(source, from: filename, to: output, map: map_param)
+
+      result.warnings.each do |warning|
+        warn "autoprefixer: #{warning}"
+      end
+
+      css = result.css
+      map = result.map && JSON.parse(result.map)
+      if previous_map && map
+        # map = ::Sprockets::SourceMapUtils.format_source_map(map, input)
+        map = ::Sprockets::SourceMapUtils.combine_source_maps previous_map, map
+      end
+
+      {
+        data: css,
+        map: map || previous_map,
+      }
     end
 
     # Add prefixes to `css`


### PR DESCRIPTION
When sprockets generate css source maps
f.e. https://github.com/sass/sassc-rails/pull/162
using autoprefixer causes source map to be incorrect.
This PR fixes mentioned problem